### PR TITLE
Update store.js

### DIFF
--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,6 +1,9 @@
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import root from './reducers';
-const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const store = createStore(root, compose(applyMiddleware(thunk)));
+const composeEnhancers =
+  process.env.NODE_ENV === 'development'
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+    : compose
+const store = createStore(root, composeEnhancers(applyMiddleware(thunk)));
 export default store;


### PR DESCRIPTION
The app crashes because the 'compose' function hasn't been imported.
Moreover, the app should not expose devtools in production mode.